### PR TITLE
Add a config generator utility

### DIFF
--- a/config-generator.rb
+++ b/config-generator.rb
@@ -1,0 +1,77 @@
+require 'yaml'
+require 'optparse'
+
+=begin
+
+The OpenShift Sidecar Audit Config Generator adds a sidecar
+logging container to the 'containers' definition in an
+OpenShift deployment configuration template.
+
+The script assumes the following:
+ - the user has a basic ruby environment installed;
+ - the user has the openshift clients installed
+
+The script can also delete all sidecar logging containers
+from a specifed deployment configuration by passing the
+'--delete' flag.
+
+=end
+
+delete=false
+
+opt_parser = OptionParser.new do |opt|
+  opt.banner = " Usage: ruby config-generator.rb DC_NAME"
+  opt.separator ""
+  opt.separator " Options:"
+
+  opt.on "-h","--help","Print help" do
+    puts opt
+    exit
+  end
+
+  opt.on "-v","--version","Display version" do
+    puts "OpenShift Audit Sidecar Config Generator v1.0.0"
+    exit
+  end
+
+  opt.on "-d","--delete","Delete audit config" do
+    delete=true
+  end 
+
+  opt.separator ""
+
+end
+
+unless ARGV[0]
+  puts opt_parser
+  exit
+end
+
+opt_parser.parse!
+
+puts "INFO :: Processing deployment config #{ARGV[0]}"
+std1 = `oc export dc #{ARGV[0]} -o yaml > deployment.yml`
+file = YAML::load_file('deployment.yml')
+
+if delete
+  puts "INFO :: Deleting the sidecar container config"
+  cons = file["spec"]["template"]["spec"]["containers"]
+  cons.delete_if do |c|
+    if c["name"] == "logging-sidecar"
+      true
+    end
+  end
+  # Set the containers back again
+  file["spec"]["template"]["spec"]["containers"] = cons
+else
+  puts "INFO :: Patching the sidecar container config"
+  template = YAML::load_file('template-fragment.yml')
+  file["spec"]["template"]["spec"]["containers"] << template
+end
+
+# Patch and cleanup
+File.open('new-dc.yml','w') {|f| f.write file.to_yaml }
+std2 = `oc replace -f new-dc.yml`
+std3 = `rm new-dc.yml`
+std4 = `rm deployment.yml`
+puts "INFO :: Successfully patched deployment config #{ARGV[0]}"

--- a/template-fragment.yml
+++ b/template-fragment.yml
@@ -1,0 +1,74 @@
+---
+name: logging-sidecar
+image: docker-registry.default.svc:5000/openshift/logging-sidecar:latest
+args:
+- /bin/bash
+- -c
+- /usr/local/bin/sidecar-logging.sh
+env:
+- name: MY_POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: CONTAINER_NAME
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: container_name
+- name: GREP_PATTERN
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: grep_pattern
+- name: SLEEP_TIME
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: sleep_time
+- name: LOG_SERVER_URI
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: log_server_uri
+- name: FEED_NAME_HEADER
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: feed_name_header
+- name: SYSTEM_NAME_HEADER
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: system_name_header
+- name: ENV_NAME_HEADER
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: env_name_header
+- name: DEDUPE
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: dedupe
+- name: GRACEFUL_EXIT_TIME
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: graceful_exit_time
+- name: STARTUP_TIME
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: startup_time
+- name: STARTUP_TIME
+  valueFrom:
+    configMapKeyRef:
+      name: logging-sidecar
+      key: startup_time
+- name: DEBUG
+  value: 'false'
+resources: 
+  requests: 
+    cpu: 100m
+    memory: 100Mi
+terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
Add a ruby CLI utility allowing users to apply the sidecar logging config to a deployment. 

Users can also delete the sidecar logging config from a deployment by passing the '--delete' flag to the utility.